### PR TITLE
feat: translate Components In-Depth - Component v-model into Turkish

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -204,7 +204,7 @@ export const sidebar: ThemeConfig['sidebar'] = {
         },
         { text: 'Props', link: '/guide/components/props' },
         { text: 'Olaylar', link: '/guide/components/events' },
-        { text: 'Component v-model', link: '/guide/components/v-model' },
+        { text: 'Bileşende v-model', link: '/guide/components/v-model' },
         {
           text: 'Fallthrough Attributes',
           link: '/guide/components/attrs'

--- a/.vitepress/theme/components/ScrimbaLink.vue
+++ b/.vitepress/theme/components/ScrimbaLink.vue
@@ -6,7 +6,7 @@
       rel="sponsored noopener"
       :title="title"
     >
-      <slot>Watch a free interactive tutorial on Scrimba</slot>
+      <slot>Scrimba'da ücretsiz interaktif bir eğitim izleyin</slot>
     </a>
   </div>
 </template>
@@ -56,4 +56,4 @@ export default {
   border-bottom: 5px solid transparent;
   border-left: 8px solid #fff;
 }
-</style> 
+</style>

--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -1,16 +1,16 @@
-# Component v-model {#component-v-model}
+# Bileşende v-model {#component-v-model}
 
-<ScrimbaLink href="https://scrimba.com/links/vue-component-v-model" title="Free Vue.js Component v-model Lesson" type="scrimba">
-  Watch an interactive video lesson on Scrimba
+<ScrimbaLink href="https://scrimba.com/links/vue-component-v-model" title="Ücretsiz Vue.js Bileşende v-model Dersi" type="scrimba">
+  Scrimba'da etkileşimli video dersini izleyin
 </ScrimbaLink>
 
-## Basic Usage {#basic-usage}
+## Temel Kullanım {#basic-usage}
 
-`v-model` can be used on a component to implement a two-way binding.
+`v-model`, bir bileşende iki yönlü bağlama uygulamak için kullanılabilir.
 
 <div class="composition-api">
 
-Starting in Vue 3.4, the recommended approach to achieve this is using the [`defineModel()`](/api/sfc-script-setup#definemodel) macro:
+Vue 3.4 itibarıyla bunu başarmanın önerilen yolu, [`defineModel()`](/api/sfc-script-setup#definemodel) makrosunu kullanmaktır:
 
 ```vue [Child.vue]
 <script setup>
@@ -27,18 +27,18 @@ function update() {
 </template>
 ```
 
-The parent can then bind a value with `v-model`:
+Üst bileşen ardından bir değeri `v-model` ile bağlayabilir:
 
 ```vue-html [Parent.vue]
 <Child v-model="countModel" />
 ```
 
-The value returned by `defineModel()` is a ref. It can be accessed and mutated like any other ref, except that it acts as a two-way binding between a parent value and a local one:
+`defineModel()` tarafından döndürülen değer bir ref’tir. Herhangi bir ref gibi erişilebilir ve değiştirilebilir; ancak üst bileşendeki bir değer ile yerel değer arasında iki yönlü bağlama oluşturur:
 
-- Its `.value` is synced with the value bound by the parent `v-model`;
-- When it is mutated by the child, it causes the parent bound value to be updated as well.
+- `.value` değeri, üst bileşendeki `v-model` ile bağlanan değerle eşitlenir;
+- Alt bileşen tarafından değiştirildiğinde, üst bileşendeki bağlanan değerin de güncellenmesini sağlar.
 
-This means you can also bind this ref to a native input element with `v-model`, making it straightforward to wrap native input elements while providing the same `v-model` usage:
+Bu ref’i yerleşik bir input öğesine de `v-model` ile bağlayabileceğiniz anlamına gelir; böylece yerleşik input'ları sarmalarken aynı `v-model` kullanımını sunmak kolaylaşır:
 
 ```vue
 <script setup>
@@ -50,16 +50,16 @@ const model = defineModel()
 </template>
 ```
 
-[Try it in the playground](https://play.vuejs.org/#eNqFUtFKwzAU/ZWYl06YLbK30Q10DFSYigq+5KW0t11mmoQknZPSf/cm3eqEsT0l555zuefmpKV3WsfbBuiUpjY3XDtiwTV6ziSvtTKOLNZcFKQ0qiZRnATkG6JB0BIDJen2kp5iMlfSOlLbisw8P4oeQAhFPpURxVV0zWSa9PNwEgIHtRaZA0SEpOvbeduG5q5LE0Sh2jvZ3tSqADFjFHlGSYJkmhz10zF1FseXvIo3VklcrfX9jOaq1lyAedGOoz1GpyQwnsvQ3fdTqDnTwPhQz9eQf52ob+zO1xh9NWDBbIHRgXOZqcD19PL9GXZ4H0h03whUnyHfwCrReI+97L6RBdo+0gW3j+H9uaw+7HLnQNrDUt6oV3ZBzyhmsjiz+p/dSTwJfUx2+IpD1ic+xz5enwQGXEDJJaw8Gl2I1upMzlc/hEvdOBR6SNKAjqP1J6P/o6XdL11L5h4=)
+[Playground’da deneyin](https://play.vuejs.org/#eNqFUtFKwzAU/ZWYl06YLbK30Q10DFSYigq+5KW0t11mmoQknZPSf/cm3eqEsT0l555zuefmpKV3WsfbBuiUpjY3XDtiwTV6ziSvtTKOLNZcFKQ0qiZRnATkG6JB0BIDJen2kp5iMlfSOlLbisw8P4oeQAhFPpURxVV0zWSa9PNwEgIHtRaZA0SEpOvbeduG5q5LE0Sh2jvZ3tSqADFjFHlGSYJkmhz10zF1FseXvIo3VklcrfX9jOaq1lyAedGOoz1GpyQwnsvQ3fdTqDnTwPhQz9eQf52ob+zO1xh9NWDBbIHRgXOZqcD19PL9GXZ4H0h03whUnyHfwCrReI+97L6RBdo+0gW3j+H9uaw+7HLnQNrDUt6oV3ZBzyhmsjiz+p/dSTwJfUx2+IpD1ic+xz5enwQGXEDJJaw8Gl2I1upMzlc/hEvdOBR6SNKAjqP1J6P/o6XdL11L5h4=)
 
-### Under the Hood {#under-the-hood}
+### Arka planda {#under-the-hood}
 
-`defineModel` is a convenience macro. The compiler expands it to the following:
+`defineModel`, kullanışlı bir makrodur. Derleyici onu şunlara açar:
 
-- A prop named `modelValue`, which the local ref's value is synced with;
-- An event named `update:modelValue`, which is emitted when the local ref's value is mutated.
+- Yerel ref’in değeriyle eşitlenen `modelValue` adlı bir prop;
+- Yerel ref’in değeri değiştirildiğinde tetiklenen `update:modelValue` adlı bir olay.
 
-This is how you would implement the same child component shown above prior to 3.4:
+Yukarıda gösterilen aynı alt bileşen, 3.4 öncesinde şu şekilde uygulanırdı:
 
 ```vue [Child.vue]
 <script setup>
@@ -75,7 +75,7 @@ const emit = defineEmits(['update:modelValue'])
 </template>
 ```
 
-Then, `v-model="foo"` in the parent component will be compiled to:
+Ardından, üst bileşendeki `v-model="foo"` ifadesi şuna derlenir:
 
 ```vue-html [Parent.vue]
 <Child
@@ -84,20 +84,20 @@ Then, `v-model="foo"` in the parent component will be compiled to:
 />
 ```
 
-As you can see, it is quite a bit more verbose. However, it is helpful to understand what is happening under the hood.
+Gördüğünüz gibi bu çok daha uzundur. Ancak, arka planda neler olduğunu anlamak faydalıdır.
 
-Because `defineModel` declares a prop, you can therefore declare the underlying prop's options by passing it to `defineModel`:
+`defineModel` bir prop bildirdiğinden, altta yatan prop’un seçeneklerini `defineModel`’e ileterek bildirebilirsiniz:
 
 ```js
-// making the v-model required
+// v-model'i zorunlu yapma
 const model = defineModel({ required: true })
 
-// providing a default value
+// varsayılan değer atama
 const model = defineModel({ default: 0 })
 ```
 
-:::warning
-If you have a `default` value for `defineModel` prop and you don't provide any value for this prop from the parent component, it can cause a de-synchronization between parent and child components. In the example below, the parent's `myRef` is undefined, but the child's `model` is 1:
+:::warning Uyarı
+`defineModel` prop’u için bir `varsayılan` değeriniz varsa ve üst bileşenden bu prop için hiçbir değer iletmezseniz, üst ve alt bileşenler arasında senkronizasyon bozukluğuna neden olabilir. Aşağıdaki örnekte üst bileşendeki `myRef` tanımsızdır, ancak alt bileşendeki `model` değeri 1’dir:
 
 ```vue [Child.vue]
 <script setup>
@@ -121,13 +121,13 @@ const myRef = ref()
 
 <div class="options-api">
 
-First let's revisit how `v-model` is used on a native element:
+Önce `v-model`’in yerleşik bir öğede nasıl kullanıldığını yeniden hatırlayalım:
 
 ```vue-html
 <input v-model="searchText" />
 ```
 
-Under the hood, the template compiler expands `v-model` to the more verbose equivalent for us. So the above code does the same as the following:
+Arka planda, şablon derleyicisi `v-model`’i bizim için daha uzun eşdeğerine açar. Dolayısıyla yukarıdaki kod, aşağıdakiyle aynı işi yapar:
 
 ```vue-html
 <input
@@ -136,7 +136,7 @@ Under the hood, the template compiler expands `v-model` to the more verbose equi
 />
 ```
 
-When used on a component, `v-model` instead expands to this:
+Bir bileşende kullanıldığında `v-model` bunun yerine şuna açılır:
 
 ```vue-html
 <CustomInput
@@ -145,12 +145,12 @@ When used on a component, `v-model` instead expands to this:
 />
 ```
 
-For this to actually work though, the `<CustomInput>` component must do two things:
+Bunun gerçekten çalışması için `<CustomInput>` bileşeninin iki şey yapması gerekir:
 
-1. Bind the `value` attribute of a native `<input>` element to the `modelValue` prop
-2. When a native `input` event is triggered, emit an `update:modelValue` custom event with the new value
+1. Yerleşik bir `<input>` öğesinin `value` özniteliğini `modelValue` prop’una bağlamak
+2. Yerleşik `input` olayı tetiklendiğinde, yeni değerle `update:modelValue` özel olayını tetiklemek
 
-Here's that in action:
+Örnek uygulama:
 
 ```vue [CustomInput.vue]
 <script>
@@ -168,15 +168,15 @@ export default {
 </template>
 ```
 
-Now `v-model` should work perfectly with this component:
+Artık `v-model` bu bileşenle sorunsuz çalışmalıdır:
 
 ```vue-html
 <CustomInput v-model="searchText" />
 ```
 
-[Try it in the Playground](https://play.vuejs.org/#eNqFkctqwzAQRX9lEAEn4Np744aWrvoD3URdiHiSGvRCHpmC8b93JDfGKYGCkJjXvTrSJF69r8aIohHtcA69p6O0vfEuELzFgZx5tz4SXIIzUFT1JpfGCmmlxe/c3uFFRU0wSQtwdqxh0dLQwHSnNJep3ilS+8PSCxCQYrC3CMDgMKgrNlB8odaOXVJ2TgdvvNp6vSwHhMZrRcgRQLs1G5+M61A/S/ErKQXUR5immwXMWW1VEKX4g3j3Mo9QfXCeKU9FtvpQmp/lM0Oi6RP/qYieebHZNvyL0acLLODNmGYSxCogxVJ6yW1c2iWz/QOnEnY48kdUpMIVGSllD8t8zVZb+PkHqPG4iw==)
+[Playground’da deneyin](https://play.vuejs.org/#eNqFkctqwzAQRX9lEAEn4Np744aWrvoD3URdiHiSGvRCHpmC8b93JDfGKYGCkJjXvTrSJF69r8aIohHtcA69p6O0vfEuELzFgZx5tz4SXIIzUFT1JpfGCmmlxe/c3uFFRU0wSQtwdqxh0dLQwHSnNJep3ilS+8PSCxCQYrC3CMDgMKgrNlB8odaOXVJ2TgdvvNp6vSwHhMZrRcgRQLs1G5+M61A/S/ErKQXUR5immwXMWW1VEKX4g3j3Mo9QfXCeKU9FtvpQmp/lM0Oi6RP/qYieebHZNvyL0acLLODNmGYSxCogxVJ6yW1c2iWz/QOnEnY48kdUpMIVGSllD8t8zVZb+PkHqPG4iw==)
 
-Another way of implementing `v-model` within this component is to use a writable `computed` property with both a getter and a setter. The `get` method should return the `modelValue` property and the `set` method should emit the corresponding event:
+Bu bileşen içinde `v-model`’i uygulamanın bir başka yolu, hem getter hem de setter içeren yazılabilir bir computed özellik kullanmaktır. `get` yöntemi `modelValue` prop’unu döndürmeli, `set` yöntemi ise karşılık gelen olayı yayımlamalıdır:
 
 ```vue [CustomInput.vue]
 <script>
@@ -203,9 +203,9 @@ export default {
 
 </div>
 
-## `v-model` Arguments {#v-model-arguments}
+## `v-model` Argümanları {#v-model-arguments}
 
-`v-model` on a component can also accept an argument:
+Bir bileşendeki `v-model` bir argüman da alabilir:
 
 ```vue-html
 <MyComponent v-model:title="bookTitle" />
@@ -213,7 +213,7 @@ export default {
 
 <div class="composition-api">
 
-In the child component, we can support the corresponding argument by passing a string to `defineModel()` as its first argument:
+Alt bileşende, karşılık gelen argümanı desteklemek için `defineModel()` fonksiyonunun ilk argümanı olarak bir string iletebiliriz:
 
 ```vue [MyComponent.vue]
 <script setup>
@@ -225,16 +225,16 @@ const title = defineModel('title')
 </template>
 ```
 
-[Try it in the Playground](https://play.vuejs.org/#eNqFklFPwjAUhf9K05dhgiyGNzJI1PCgCWqUx77McQeFrW3aOxxZ9t+9LTAXA/q2nnN6+t12Db83ZrSvgE944jIrDTIHWJmZULI02iJrmIWctSy3umQRRaPOWhweNX0pUHiyR3FP870UZkyoTCuH7FPr3VJiAWzqSwfR/rbUKyhYatdV6VugTktTQHQjVBIfeYiEFgikpwi0YizZ3M2aplfXtklMWvD6UKf+CfrUVPBuh+AspngSd718yH+hX7iS4xihjUZYQS4VLPwJgyiI/3FLZSrafzAeBqFG4jgxeuEqGTo6OZfr0dZpRVxNuFWeEa4swL4alEQm+IQFx3tpUeiv56ChrWB41rMNZLsL+tbVXhP8zYIDuyeQzkN6HyBWb88/XgJ3ZxJ95bH/MN/B6aLyjMfYQ6VWhN3LBdqn8FdJtV66eY2g3HkoD+qTbcgLTo/jX+ra6D+449E47BOq5e039mr+gA==)
+[Playground’da deneyin](https://play.vuejs.org/#eNqFklFPwjAUhf9K05dhgiyGNzJI1PCgCWqUx77McQeFrW3aOxxZ9t+9LTAXA/q2nnN6+t12Db83ZrSvgE944jIrDTIHWJmZULI02iJrmIWctSy3umQRRaPOWhweNX0pUHiyR3FP870UZkyoTCuH7FPr3VJiAWzqSwfR/rbUKyhYatdV6VugTktTQHQjVBIfeYiEFgikpwi0YizZ3M2aplfXtklMWvD6UKf+CfrUVPBuh+AspngSd718yH+hX7iS4xihjUZYQS4VLPwJgyiI/3FLZSrafzAeBqFG4jgxeuEqGTo6OZfr0dZpRVxNuFWeEa4swL4alEQm+IQFx3tpUeiv56ChrWB41rMNZLsL+tbVXhP8zYIDuyeQzkN6HyBWb88/XgJ3ZxJ95bH/MN/B6aLyjMfYQ6VWhN3LBdqn8FdJtV66eY2g3HkoD+qTbcgLTo/jX+ra6D+449E47BOq5e039mr+gA==)
 
-If prop options are also needed, they should be passed after the model name:
+Prop seçenekleri de gerekiyorsa, model adından sonra iletilmelidir:
 
 ```js
 const title = defineModel('title', { required: true })
 ```
 
 <details>
-<summary>Pre 3.4 Usage</summary>
+<summary>3.4 Öncesi Kullanım</summary>
 
 ```vue [MyComponent.vue]
 <script setup>
@@ -255,13 +255,13 @@ defineEmits(['update:title'])
 </template>
 ```
 
-[Try it in the Playground](https://play.vuejs.org/#eNp9kE1rwzAMhv+KMIW00DXsGtKyMXYc7D7vEBplM8QfOHJoCfnvk+1QsjJ2svVKevRKk3h27jAGFJWoh7NXjmBACu4kjdLOeoIJPHYwQ+ethoJLi1vq7fpi+WfQ0JI+lCstcrkYQJqzNQMBKeoRjhG4LcYHbVvsofFfQUcCXhrteix20tRl9sIuOCBkvSHkCKD+fjxN04Ka57rkOOlrMwu7SlVHKdIrBZRcWpc3ntiLO7t/nKHFThl899YN248ikYpP9pj1V60o6sG1TMwDU/q/FZRxgeIPgK4uGcQLSZGlamz6sHKd1afUxOoGeeT298A9bHCMKxBfE3mTSNjl1vud5x8qNa76)
+[Playground’da deneyin](https://play.vuejs.org/#eNp9kE1rwzAMhv+KMIW00DXsGtKyMXYc7D7vEBplM8QfOHJoCfnvk+1QsjJ2svVKevRKk3h27jAGFJWoh7NXjmBACu4kjdLOeoIJPHYwQ+ethoJLi1vq7fpi+WfQ0JI+lCstcrkYQJqzNQMBKeoRjhG4LcYHbVvsofFfQUcCXhrteix20tRl9sIuOCBkvSHkCKD+fjxN04Ka57rkOOlrMwu7SlVHKdIrBZRcWpc3ntiLO7t/nKHFThl899YN248ikYpP9pj1V60o6sG1TMwDU/q/FZRxgeIPgK4uGcQLSZGlamz6sHKd1afUxOoGeeT298A9bHCMKxBfE3mTSNjl1vud5x8qNa76)
 
 </details>
 </div>
 <div class="options-api">
 
-In this case, instead of the default `modelValue` prop and `update:modelValue` event, the child component should expect a `title` prop and emit an `update:title` event to update the parent value:
+Bu durumda, varsayılan `modelValue` prop’u ve `update:modelValue` olayı yerine alt bileşen bir `title` prop’u beklemeli ve üst bileşendeki değeri güncellemek için `update:title` olayını tetiklemelidir:
 
 ```vue [MyComponent.vue]
 <script>
@@ -280,15 +280,15 @@ export default {
 </template>
 ```
 
-[Try it in the Playground](https://play.vuejs.org/#eNqFUNFqwzAM/BVhCm6ha9hryMrGnvcFdR9Mo26B2DGuHFJC/n2yvZakDAohtuTTne5G8eHcrg8oSlFdTr5xtFe2Ma7zBF/Xz45vFi3B2XcG5K6Y9eKYVFZZHBK8xrMOLcGoLMDphrqUMC6Ypm18rzXp9SZjATxS8PZWAVBDLZYg+xfT1diC9t/BxGEctHFtlI2wKR78468q7ttzQcgoTcgVQPXzuh/HzAnTVBVcp/58qz+lMqHelEinElAwtCrufGIrHhJYBPdfEs53jkM4yEQpj8k+miYmc5DBcRKYZeXxqZXGukDZPF1dWhQHUiK3yl63YbZ97r6nIe6uoup6KbmFFfbRCnHGyI4iwyaPPnqffgGMlsEM)
+[Playground’da deneyin](https://play.vuejs.org/#eNqFUNFqwzAM/BVhCm6ha9hryMrGnvcFdR9Mo26B2DGuHFJC/n2yvZakDAohtuTTne5G8eHcrg8oSlFdTr5xtFe2Ma7zBF/Xz45vFi3B2XcG5K6Y9eKYVFZZHBK8xrMOLcGoLMDphrqUMC6Ypm18rzXp9SZjATxS8PZWAVBDLZYg+xfT1diC9t/BxGEctHFtlI2wKR78468q7ttzQcgoTcgVQPXzuh/HzAnTVBVcp/58qz+lMqHelEinElAwtCrufGIrHhJYBPdfEs53jkM4yEQpj8k+miYmc5DBcRKYZeXxqZXGukDZPF1dWhQHUiK3yl63YbZ97r6nIe6uoup6KbmFFfbRCnHGyI4iwyaPPnqffgGMlsEM)
 
 </div>
 
-## Multiple `v-model` Bindings {#multiple-v-model-bindings}
+## Birden Fazla `v-model` Bağlaması {#multiple-v-model-bindings}
 
-By leveraging the ability to target a particular prop and event as we learned before with [`v-model` arguments](#v-model-arguments), we can now create multiple `v-model` bindings on a single component instance.
+Daha önce [`v-model` argümanları](#v-model-arguments) ile belirli bir prop ve olayı hedefleme konusunda öğrendiğimiz bilgileri kullanarak, tek bir bileşen örneğinde birden fazla `v-model` bağlaması oluşturabiliriz.
 
-Each `v-model` will sync to a different prop, without the need for extra options in the component:
+Her `v-model`, bileşende ek seçenek gerekmeden farklı bir prop ile eşitlenir:
 
 ```vue-html
 <UserName
@@ -311,10 +311,10 @@ const lastName = defineModel('lastName')
 </template>
 ```
 
-[Try it in the Playground](https://play.vuejs.org/#eNqFkstuwjAQRX/F8iZUAqKKHQpIfbAoUmnVx86bKEzANLEt26FUkf+9Y4MDSAg2UWbu9fjckVv6oNRw2wAd08wUmitLDNhGTZngtZLakpZoKIkjpZY1SdCadNK3Ab3IazhowzQ2/ES0MVFIYSwpucbvxA/qJXO5FsldlKr8qDxL8EKW7kEQAQsLtapyC1gRkq3vp217mOccwf8wwLksRSlYIoMvCNkOarmEahyODAT2J4yGgtFzhx8UDf5/r6c4NEs7CNqnpxkvbO0kcVjNhCyh5AJe/SW9pBPOV3DJGvu3dsKFaiyxf8qTW9gheQwVs4Z90BDm5oF47cF/Ht4aZC75argxUmD61g9ktJC14hXoN2U5ZmJ0TILitbyq5O889KxuoB/7xRqKnwv9jdn5HqPvGnDVWwTpNJvrFSCul2efi4DeiRigqdB9RfwAI6vGM+5tj41YIvaJL9C+hOfNxerLzHYWhImhPKh3uuBnFJ/A05XoR9zRcBTOMeGo+wcs+yse)
+[Playground’da deneyin](https://play.vuejs.org/#eNqFkstuwjAQRX/F8iZUAqKKHQpIfbAoUmnVx86bKEzANLEt26FUkf+9Y4MDSAg2UWbu9fjckVv6oNRw2wAd08wUmitLDNhGTZngtZLakpZoKIkjpZY1SdCadNK3Ab3IazhowzQ2/ES0MVFIYSwpucbvxA/qJXO5FsldlKr8qDxL8EKW7kEQAQsLtapyC1gRkq3vp217mOccwf8wwLksRSlYIoMvCNkOarmEahyODAT2J4yGgtFzhx8UDf5/r6c4NEs7CNqnpxkvbO0kcVjNhCyh5AJe/SW9pBPOV3DJGvu3dsKFaiyxf8qTW9gheQwVs4Z90BDm5oF47cF/Ht4aZC75argxUmD61g9ktJC14hXoN2U5ZmJ0TILitbyq5O889KxuoB/7xRqKnwv9jdn5HqPvGnDVWwTpNJvrFSCul2efi4DeiRigqdB9RfwAI6vGM+5tj41YIvaJL9C+hOfNxerLzHYWhImhPKh3uuBnFJ/A05XoR9zRcBTOMeGo+wcs+yse)
 
 <details>
-<summary>Pre 3.4 Usage</summary>
+<summary>3.4 Öncesi Kullanım</summary>
 
 ```vue
 <script setup>
@@ -340,7 +340,7 @@ defineEmits(['update:firstName', 'update:lastName'])
 </template>
 ```
 
-[Try it in the Playground](https://play.vuejs.org/#eNqNUc1qwzAMfhVjCk6hTdg1pGWD7bLDGIydlh1Cq7SGxDaOEjaC332yU6cdFNpLsPRJ348y8idj0qEHnvOi21lpkHWAvdmWSrZGW2Qjs1Azx2qrWyZoVMzQZwf2rWrhhKVZbHhGGivVTqsOWS0tfTeeKBGv+qjEMkJNdUaeNXigyCYjZIEKhNY0FQJVjBXHh+04nvicY/QOBM4VGUFhJHrwBWPDutV7aPKwslbU35Q8FCX/P+GJ4oB/T3hGpEU2m+ArfpnxytX2UEsF71abLhk9QxDzCzn7QCvVYeW7XuGyWSpH0eP6SyuxS75Eb/akOpn302LFYi8SiO8bJ5PK9DhFxV/j0yH8zOnzoWr6+SbhbifkMSwSsgByk1zzsoABFKZY2QNgGpiW57Pdrx2z3JCeI99Svvxh7g8muf2x)
+[Playground’da deneyin](https://play.vuejs.org/#eNqNUc1qwzAMfhVjCk6hTdg1pGWD7bLDGIydlh1Cq7SGxDaOEjaC332yU6cdFNpLsPRJ348y8idj0qEHnvOi21lpkHWAvdmWSrZGW2Qjs1Azx2qrWyZoVMzQZwf2rWrhhKVZbHhGGivVTqsOWS0tfTeeKBGv+qjEMkJNdUaeNXigyCYjZIEKhNY0FQJVjBXHh+04nvicY/QOBM4VGUFhJHrwBWPDutV7aPKwslbU35Q8FCX/P+GJ4oB/T3hGpEU2m+ArfpnxytX2UEsF71abLhk9QxDzCzn7QCvVYeW7XuGyWSpH0eP6SyuxS75Eb/akOpn302LFYi8SiO8bJ5PK9DhFxV/j0yH8zOnzoWr6+SbhbifkMSwSsgByk1zzsoABFKZY2QNgGpiW57Pdrx2z3JCeI99Svvxh7g8muf2x)
 
 </details>
 </div>
@@ -371,15 +371,15 @@ export default {
 </template>
 ```
 
-[Try it in the Playground](https://play.vuejs.org/#eNqNkk1rg0AQhv/KIAETSJRexYYWeuqhl9JTt4clmSSC7i7rKCnif+/ObtYkELAiujPzztejQ/JqTNZ3mBRJ2e5sZWgrVNUYbQm+WrQfskE4WN1AmuXRwQmpUELh2Qv3eJBdTTAIBbDTLluhoraA4VpjXHNwL0kuV0EIYJE6q6IFcKhsSwWk7/qkUq/nq5be+aa5JztGfrmHu8t8GtoZhI2pJaGzAMrT03YYQk0YR3BnruSOZe5CXhKnC3X7TaP3WBc+ZaOc/1kk3hDJvYILRQGfQzx3Rct8GiJZJ7fA7gg/AmesNszMrUIXFpxbwCfZSh09D0Hc7tbN6sAWm4qZf6edcZgxrMHSdA3RF7PTn1l8lTIdhbXp1/CmhOeJRNHLupv4eIaXyItPdJEFD7R8NM0Ce/d/ZCTtESnzlVZXhP/vHbeZaT0tPdf59uONfx7mDVM=)
+[Playground’da deneyin](https://play.vuejs.org/#eNqNkk1rg0AQgF9lkIKGpqa9iikNOefUtJfaw6KTZEHdZR1DbPDdO7saf0qgIq47//PNXL2N1uG5Ri/y4io1UtNrUspCK0Owa7aK/0osCQ5GFeCHq4nMuvlJCZCUeHEOGR5EnRNcrTS92VURXGex2qXVZ4JEsOhsAQxSbcrbDaBo9nihCHyXAaC1B3/4jVdDoXwhLHQuCPkGsD/JCmSpa4JUaEkilz9YAZ7RNHSS5REaVQPXgCay9vG0rPNToTLMw9FznXhdHYkHK04Qr4Zs3tL7g2JG8B4QbZS2LLqGXK5PkdcYwTsZrs1R6RU7lcmDRDPaM7AuWARMbf0KwbVdTNk4dyyk5f3l15r5YjRm8b+dQYF0UtkY1jo4fYDDLAByZBxWCmvAkIQ5IvdoBTcLeYCAiVbhvNwJvEk4GIK5M0xPwmwoeF6EpD60RrMVFXJXj72+ymWKwUvfXt+gfVzGB1tzcKfDZec+o/LfxsTdtlCj7bSpm3Xk4tjpD8FZ+uZMWTowu7MW7S+CWR77)
 
 </div>
 
-## Handling `v-model` Modifiers {#handling-v-model-modifiers}
+## `v-model` Değiştiricilerini İşleme {#handling-v-model-modifiers}
 
-When we were learning about form input bindings, we saw that `v-model` has [built-in modifiers](/guide/essentials/forms#modifiers) - `.trim`, `.number` and `.lazy`. In some cases, you might also want the `v-model` on your custom input component to support custom modifiers.
+Form input bağlamalarını incelerken, `v-model`’in [yerleşik değiştiricilere](/guide/essentials/forms#modifiers) sahip olduğunu görmüştük: `.trim`, `.number` ve `.lazy`. Bazı durumlarda özel input bileşeninizdeki `v-model`’in özel değiştiricileri desteklemesini de isteyebilirsiniz.
 
-Let's create an example custom modifier, `capitalize`, that capitalizes the first letter of the string provided by the `v-model` binding:
+Özel bir değiştirici örneği olan `capitalize` ile `v-model` bağlamasının sağladığı string'in ilk harfini büyütelim:
 
 ```vue-html
 <MyComponent v-model.capitalize="myText" />
@@ -387,7 +387,7 @@ Let's create an example custom modifier, `capitalize`, that capitalizes the firs
 
 <div class="composition-api">
 
-Modifiers added to a component `v-model` can be accessed in the child component by destructuring the `defineModel()` return value like this:
+Bileşen `v-model`’ine eklenen değiştiricilere, alt bileşende `defineModel()` dönüş değerini şu şekilde parçalayarak erişebilirsiniz:
 
 ```vue{4}
 <script setup>
@@ -401,7 +401,7 @@ console.log(modifiers) // { capitalize: true }
 </template>
 ```
 
-To conditionally adjust how the value should be read / written based on modifiers, we can pass `get` and `set` options to `defineModel()`. These two options receive the value on get / set of the model ref and should return a transformed value. This is how we can use the `set` option to implement the `capitalize` modifier:
+Değiştiricilere göre değerin nasıl okunup yazılacağını koşullu olarak ayarlamak için `defineModel()`’e `get` ve `set` seçeneklerini iletebilirsiniz. Bu iki seçenek model ref’inin okunması ve yazılması sırasında gelen değeri alır ve dönüştürülmüş bir değer döndürmelidir. `capitalize` değiştiricisini uygulamak için `set` seçeneğini şöyle kullanabilirsiniz:
 
 ```vue{4-6}
 <script setup>
@@ -420,10 +420,10 @@ const [model, modifiers] = defineModel({
 </template>
 ```
 
-[Try it in the Playground](https://play.vuejs.org/#eNp9UsFu2zAM/RVClzhY5mzoLUgHdEUPG9Bt2LLTtIPh0Ik6WRIkKksa5N9LybFrFG1OkvgeyccnHsWNc+UuoliIZai9cgQBKbpP0qjWWU9wBI8NnKDxtoUJUycDdH+4tXwzaOgMl/NRLNVlMoA0tTWBoD2scE9wnSoWk8lUmuW8a8rt+EHYOl0R8gtgtVUBlHGRoK6cokqrRwxAW4RGea6mkQg9HGwEboZ+kbKWY027961doy6f86+l6ERIAXNus5wPPcVMvNB+yZOaiZFw/cKYftI/ufEM+FCNQh/+8tRrbJTB+4QUxySWqxa7SkecQn4DqAaKIWekeyAAe0fRG8h5Zb2t/A0VH6Yl2d/Oob+tAhZTeHfGg1Y1Fh/Z6ZR66o5xhRTh8OnyXyy7f6CDSw5S59/Z3WRpOl91lAL70ahN+RCsYT/zFFIk95RG/92RYr+kWPTzSVFpbf9/zTHyEWd9vN5i/e+V+EPYp5gUPzwG9DuUYsCo8htkrQm++/Ut6x5AVh01sy+APzFYHZPGjvY5mjXLHvGy2i95K5TZrMLdntCEfqgkNDuc+VLwkqQNe2v0Z7lX5VX/M+L0BFEuPdc=)
+[Playground’da deneyin](https://play.vuejs.org/#eNp9UsFu2zAM/RVClzhY5mzoLUgHdEUPG9Bt2LLTtIPh0Ik6WRIkKksa5N9LybFrFG1OkvgeyccnHsWNc+UuoliIZai9cgQBKbpP0qjWWU9wBI8NnKDxtoUJUycDdH+4tXwzaOgMl/NRLNVlMoA0tTWBoD2scE9wnSoWk8lUmuW8a8rt+EHYOl0R8gtgtVUBlHGRoK6cokqrRwxAW4RGea6mkQg9HGwEboZ+kbKWY027961doy6f86+l6ERIAXNus5wPPcVMvNB+yZOaiZFw/cKYftI/ufEM+FCNQh/+8tRrbJTB+4QUxySWqxa7SkecQn4DqAaKIWekeyAAe0fRG8h5Zb2t/A0VH6Yl2d/Oob+tAhZTeHfGg1Y1Fh/Z6ZR66o5xhRTh8OnyXyy7f6CDSw5S59/Z3WRpOl91lAL70ahN+RCsYT/zFFIk95RG/92RYr+kWPTzSVFpbf9/zTHyEWd9vN5i/e+V+EPYp5gUPzwG9DuUYsCo8htkrQm++/Ut6x5AVh01sy+APzFYHZPGjvY5mjXLHvGy2i95K5TZrMLdntCEfqgkNDuc+VLwkqQNe2v0Z7lX5VX/M+L0BFEuPdc=)
 
 <details>
-<summary>Pre 3.4 Usage</summary>
+<summary>3.4 Öncesi Kullanım</summary>
 
 ```vue{11-13}
 <script setup>
@@ -448,14 +448,14 @@ function emitValue(e) {
 </template>
 ```
 
-[Try it in the Playground](https://play.vuejs.org/#eNp9Us1Og0AQfpUJF5ZYqV4JNTaNxyYmVi/igdCh3QR2N7tDIza8u7NLpdU0nmB+v5/ZY7Q0Jj10GGVR7iorDYFD6sxDoWRrtCU4gsUaBqitbiHm1ngqrfuV5j+Fik7ldH6R83u5GaBQlVaOoO03+Emw8BtFHCeFyucjKMNxQNiapiTkCGCzlw6kMh1BVRpJZSO/0AEe0Pa0l2oHve6AYdBmvj+/ZHO4bfUWm/Q8uSiiEb6IYM4A+XxCi2bRH9ZX3BgVGKuNYwFbrKXCZx+Jo0cPcG9l02EGL2SZ3mxKr/VW1hKty9hMniy7hjIQCSweQByHBIZCDWzGDwi20ps0Yjxx4MR73Jktc83OOPFHGKk7VZHUKkyFgsAEAqcG2Qif4WWYUml3yOp8wldlDSLISX+TvPDstAemLeGbVvvSLkncJSnpV2PQrkqHLOfmVHeNrFDcMz3w0iBQE1cUzMYBbuS2f55CPj4D6o0/I41HzMKsP+u0kLOPoZWzkx1X7j18A8s0DEY=)
+[Playground’da deneyin](https://play.vuejs.org/#eNp9Us1Og0AQfpUJF5ZYqV4JNTaNxyYmVi/igdCh3QR2N7tDIza8u7NLpdU0nmB+v5/ZY7Q0Jj10GGVR7iorDYFD6sxDoWRrtCU4gsUaBqitbiHm1ngqrfuV5j+Fik7ldH6R83u5GaBQlVaOoO03+Emw8BtFHCeFyucjKMNxQNiapiTkCGCzlw6kMh1BVRpJZSO/0AEe0Pa0l2oHve6AYdBmvj+/ZHO4bfUWm/Q8uSiiEb6IYM4A+XxCi2bRH9ZX3BgVGKuNYwFbrKXCZx+Jo0cPcG9l02EGL2SZ3mxKr/VW1hKty9hMniy7hjIQCSweQByHBIZCDWzGDwi20ps0Yjxx4MR73Jktc83OOPFHGKk7VZHUKkyFgsAEAqcG2Qif4WWYUml3yOp8wldlDSLISX+TvPDstAemLeGbVvvSLkncJSnpV2PQrkqHLOfmVHeNrFDcMz3w0iBQE1cUzMYBbuS2f55CPj4D6o0/I41HzMKsP+u0kLOPoZWzkx1X7j18A8s0DEY=)
 
 </details>
 </div>
 
 <div class="options-api">
 
-Modifiers added to a component `v-model` will be provided to the component via the `modelModifiers` prop. In the below example, we have created a component that contains a `modelModifiers` prop that defaults to an empty object:
+Bileşen `v-model`’ine eklenen değiştiriciler `modelModifiers` prop’u üzerinden bileşene iletilir. Aşağıdaki örnekte, varsayılan değeri boş bir nesne olan bir `modelModifiers` prop’u içeren bir bileşen oluşturduk:
 
 ```vue{11}
 <script>
@@ -482,9 +482,9 @@ export default {
 </template>
 ```
 
-Notice the component's `modelModifiers` prop contains `capitalize` and its value is `true` - due to it being set on the `v-model` binding `v-model.capitalize="myText"`.
+Bileşenin `modelModifiers` prop’unun `capitalize` içerdiğine ve değerinin `true` olduğuna dikkat edin — bunun nedeni `v-model.capitalize="myText"` bağlamasında ayarlanmış olmasıdır.
 
-Now that we have our prop set up, we can check the `modelModifiers` object keys and write a handler to change the emitted value. In the code below we will capitalize the string whenever the `<input />` element fires an `input` event.
+Prop’umuzu kurduğumuza göre, `modelModifiers` nesnesinin anahtarlarını kontrol edebilir ve yayımlanan değeri değiştiren bir işleyici yazabiliriz. Aşağıdaki kodda, `<input />` öğesi `input` olayı tetiklediğinde string'in ilk harfini büyüteceğiz.
 
 ```vue{13-15}
 <script>
@@ -513,21 +513,21 @@ export default {
 </template>
 ```
 
-[Try it in the Playground](https://play.vuejs.org/#eNqFks1qg0AQgF9lkIKGpqa9iikNOefUtJfaw6KTZEHdZR1DbPDdO7saf0qgIq47//PNXL2N1uG5Ri/y4io1UtNrUspCK0Owa7aK/0osCQ5GFeCHq4nMuvlJCZCUeHEOGR5EnRNcrTS92VURXGex2qXVZ4JEsOhsAQxSbcrbDaBo9nihCHyXAaC1B3/4jVdDoXwhLHQuCPkGsD/JCmSpa4JUaEkilz9YAZ7RNHSS5REaVQPXgCay9vG0rPNToTLMw9FznXhdHYkHK04Qr4Zs3tL7g2JG8B4QbZS2LLqGXK5PkdcYwTsZrs1R6RU7lcmDRDPaM7AuWARMbf0KwbVdTNk4dyyk5f3l15r5YjRm8b+dQYF0UtkY1jo4fYDDLAByZBxWCmvAkIQ5IvdoBTcLeYCAiVbhvNwJvEk4GIK5M0xPwmwoeF6EpD60RrMVFXJXj72+ymWKwUvfXt+gfVzGB1tzcKfDZec+o/LfxsTdtlCj7bSpm3Xk4tjpD8FZ+uZMWTowu7MW7S+CWR77)
+[Playground’da deneyin](https://play.vuejs.org/#eNqFks1qg0AQgF9lkIKGpqa9iikNOefUtJfaw6KTZEHdZR1DbPDdO7saf0qgIq47//PNXL2N1uG5Ri/y4io1UtNrUspCK0Owa7aK/0osCQ5GFeCHq4nMuvlJCZCUeHEOGR5EnRNcrTS92VURXGex2qXVZ4JEsOhsAQxSbcrbDaBo9nihCHyXAaC1B3/4jVdDoXwhLHQuCPkGsD/JCmSpa4JUaEkilz9YAZ7RNHSS5REaVQPXgCay9vG0rPNToTLMw9FznXhdHYkHK04Qr4Zs3tL7g2JG8B4QbZS2LLqGXK5PkdcYwTsZrs1R6RU7lcmDRDPaM7AuWARMbf0KwbVdTNk4dyyk5f3l15r5YjRm8b+dQYF0UtkY1jo4fYDDLAByZBxWCmvAkIQ5IvdoBTcLeYCAiVbhvNwJvEk4GIK5M0xPwmwoeF6EpD60RrMVFXJXj72+ymWKwUvfXt+gfVzGB1tzcKfDZec+o/LfxsTdtlCj7bSpm3Xk4tjpD8FZ+uZMWTowu7MW7S+CWR77)
 
 </div>
 
-### Modifiers for `v-model` with Arguments {#modifiers-for-v-model-with-arguments}
+### Argümanlı `v-model` için Değiştiriciler {#modifiers-for-v-model-with-arguments}
 
 <div class="options-api">
 
-For `v-model` bindings with both argument and modifiers, the generated prop name will be `arg + "Modifiers"`. For example:
+Hem argüman hem de değiştirici içeren `v-model` bağlamalarında üretilen prop adı `arg + "Modifiers"` olur. Örneğin:
 
 ```vue-html
 <MyComponent v-model:title.capitalize="myText">
 ```
 
-The corresponding declarations should be:
+Karşılık gelen bildirimler şöyle olmalıdır:
 
 ```js
 export default {
@@ -541,7 +541,7 @@ export default {
 
 </div>
 
-Here's another example of using modifiers with multiple `v-model` with different arguments:
+Farklı argümanlara sahip birden fazla `v-model` ile değiştirici kullanımına ilişkin bir başka örnek:
 
 ```vue-html
 <UserName
@@ -563,7 +563,7 @@ console.log(lastNameModifiers) // { uppercase: true }
 ```
 
 <details>
-<summary>Pre 3.4 Usage</summary>
+<summary>3.4 Öncesi Kullanım</summary>
 
 ```vue{5,6,10,11}
 <script setup>

--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -54,7 +54,7 @@ const model = defineModel()
 
 ### Arka planda {#under-the-hood}
 
-`defineModel`, kullanışlı bir makrodur. Derleyici onu şunlara açar:
+`defineModel`, kullanışlı bir makrodur. Derleyici bunu aşağıdakilere dönüştürür:
 
 - Yerel ref’in değeriyle eşitlenen `modelValue` adlı bir prop;
 - Yerel ref’in değeri değiştirildiğinde tetiklenen `update:modelValue` adlı bir olay.
@@ -97,7 +97,7 @@ const model = defineModel({ default: 0 })
 ```
 
 :::warning Uyarı
-`defineModel` prop’u için bir `varsayılan` değeriniz varsa ve üst bileşenden bu prop için hiçbir değer iletmezseniz, üst ve alt bileşenler arasında senkronizasyon bozukluğuna neden olabilir. Aşağıdaki örnekte üst bileşendeki `myRef` tanımsızdır, ancak alt bileşendeki `model` değeri 1’dir:
+`defineModel` prop’u için bir `default` değeriniz varsa ve üst bileşenden bu prop için hiçbir değer iletmezseniz, üst ve alt bileşenler arasında senkronizasyon bozulmasına neden olabilir. Aşağıdaki örnekte üst bileşendeki `myRef` tanımsızdır, ancak alt bileşendeki `model` değeri 1’dir:
 
 ```vue [Child.vue]
 <script setup>
@@ -127,7 +127,7 @@ const myRef = ref()
 <input v-model="searchText" />
 ```
 
-Arka planda, şablon derleyicisi `v-model`’i bizim için daha uzun eşdeğerine açar. Dolayısıyla yukarıdaki kod, aşağıdakiyle aynı işi yapar:
+Arka planda, şablon derleyicisi `v-model`’i bizim için daha uzun eşdeğerine dönüştürür. Dolayısıyla yukarıdaki kod, aşağıdakiyle aynı işi yapar:
 
 ```vue-html
 <input
@@ -136,7 +136,7 @@ Arka planda, şablon derleyicisi `v-model`’i bizim için daha uzun eşdeğerin
 />
 ```
 
-Bir bileşende kullanıldığında `v-model` bunun yerine şuna açılır:
+Bir bileşende kullanıldığında `v-model` bunun yerine şuna dönüşür:
 
 ```vue-html
 <CustomInput
@@ -147,8 +147,8 @@ Bir bileşende kullanıldığında `v-model` bunun yerine şuna açılır:
 
 Bunun gerçekten çalışması için `<CustomInput>` bileşeninin iki şey yapması gerekir:
 
-1. Yerleşik bir `<input>` öğesinin `value` özniteliğini `modelValue` prop’una bağlamak
-2. Yerleşik `input` olayı tetiklendiğinde, yeni değerle `update:modelValue` özel olayını tetiklemek
+1. Yerleşik bir `<input>` öğesinin `value` özniteliğini `modelValue` prop’una bağlamalı
+2. Yerleşik `input` olayı tetiklendiğinde, yeni değerle `update:modelValue` özel olayını tetiklemeli
 
 Örnek uygulama:
 
@@ -213,7 +213,7 @@ Bir bileşendeki `v-model` bir argüman da alabilir:
 
 <div class="composition-api">
 
-Alt bileşende, karşılık gelen argümanı desteklemek için `defineModel()` fonksiyonunun ilk argümanı olarak bir string iletebiliriz:
+Alt bileşende, karşılık gelen argümanı desteklemek için `defineModel()` fonksiyonunun ilk argümanı olarak bir string değer iletebiliriz:
 
 ```vue [MyComponent.vue]
 <script setup>
@@ -371,7 +371,7 @@ export default {
 </template>
 ```
 
-[Playground’da deneyin](https://play.vuejs.org/#eNqNkk1rg0AQgF9lkIKGpqa9iikNOefUtJfaw6KTZEHdZR1DbPDdO7saf0qgIq47//PNXL2N1uG5Ri/y4io1UtNrUspCK0Owa7aK/0osCQ5GFeCHq4nMuvlJCZCUeHEOGR5EnRNcrTS92VURXGex2qXVZ4JEsOhsAQxSbcrbDaBo9nihCHyXAaC1B3/4jVdDoXwhLHQuCPkGsD/JCmSpa4JUaEkilz9YAZ7RNHSS5REaVQPXgCay9vG0rPNToTLMw9FznXhdHYkHK04Qr4Zs3tL7g2JG8B4QbZS2LLqGXK5PkdcYwTsZrs1R6RU7lcmDRDPaM7AuWARMbf0KwbVdTNk4dyyk5f3l15r5YjRm8b+dQYF0UtkY1jo4fYDDLAByZBxWCmvAkIQ5IvdoBTcLeYCAiVbhvNwJvEk4GIK5M0xPwmwoeF6EpD60RrMVFXJXj72+ymWKwUvfXt+gfVzGB1tzcKfDZec+o/LfxsTdtlCj7bSpm3Xk4tjpD8FZ+uZMWTowu7MW7S+CWR77)
+[Playground’da deneyin](https://play.vuejs.org/#eNqNkk1rg0AQhv/KIAETSJRexYYWeuqhl9JTt4clmSSC7i7rKCnif+/ObtYkELAiujPzztejQ/JqTNZ3mBRJ2e5sZWgrVNUYbQm+WrQfskE4WN1AmuXRwQmpUELh2Qv3eJBdTTAIBbDTLluhoraA4VpjXHNwL0kuV0EIYJE6q6IFcKhsSwWk7/qkUq/nq5be+aa5JztGfrmHu8t8GtoZhI2pJaGzAMrT03YYQk0YR3BnruSOZe5CXhKnC3X7TaP3WBc+ZaOc/1kk3hDJvYILRQGfQzx3Rct8GiJZJ7fA7gg/AmesNszMrUIXFpxbwCfZSh09D0Hc7tbN6sAWm4qZf6edcZgxrMHSdA3RF7PTn1l8lTIdhbXp1/CmhOeJRNHLupv4eIaXyItPdJEFD7R8NM0Ce/d/ZCTtESnzlVZXhP/vHbeZaT0tPdf59uONfx7mDVM=)
 
 </div>
 
@@ -379,7 +379,7 @@ export default {
 
 Form input bağlamalarını incelerken, `v-model`’in [yerleşik değiştiricilere](/guide/essentials/forms#modifiers) sahip olduğunu görmüştük: `.trim`, `.number` ve `.lazy`. Bazı durumlarda özel input bileşeninizdeki `v-model`’in özel değiştiricileri desteklemesini de isteyebilirsiniz.
 
-Özel bir değiştirici örneği olan `capitalize` ile `v-model` bağlamasının sağladığı string'in ilk harfini büyütelim:
+Özel bir değiştirici örneği olan `capitalize` ile `v-model` bağlamasının sağladığı string değerin ilk harfini büyütelim:
 
 ```vue-html
 <MyComponent v-model.capitalize="myText" />
@@ -484,7 +484,7 @@ export default {
 
 Bileşenin `modelModifiers` prop’unun `capitalize` içerdiğine ve değerinin `true` olduğuna dikkat edin — bunun nedeni `v-model.capitalize="myText"` bağlamasında ayarlanmış olmasıdır.
 
-Prop’umuzu kurduğumuza göre, `modelModifiers` nesnesinin anahtarlarını kontrol edebilir ve yayımlanan değeri değiştiren bir işleyici yazabiliriz. Aşağıdaki kodda, `<input />` öğesi `input` olayı tetiklediğinde string'in ilk harfini büyüteceğiz.
+Prop’umuzu kurduğumuza göre, `modelModifiers` nesnesinin anahtarlarını kontrol edebilir ve yayımlanan değeri değiştiren bir işleyici yazabiliriz. Aşağıdaki kodda, `<input />` öğesi `input` olayı tetiklediğinde string değerin ilk harfini büyüteceğiz.
 
 ```vue{13-15}
 <script>


### PR DESCRIPTION
## 📝 Çeviri Özeti
Bu Pull Request, `Components In-Depth - Component v-model` sayfasının Türkçeleştirilmesini içermektedir.

- **İlgili Issue:** #41   
- **Dosya Yolu:** `src/guide/components/v-model.md`
- **Ek Dosya Yolları:** 
    - `.vitepress/config.ts` => `Component v-model` sayfa başlığı Türkçe'ye çevrildi.
    - `.vitepress/theme/components/ScrimbaLink.vue`  => `Scrimba`'ya yönlendiren link Türkçe'ye çevrildi.

## ✅ Kontrol Listesi
PR gönderilmeden önce aşağıdaki maddelere dikkat edildi:

- ✅ **Eksiksiz Çeviri:** Sayfadaki tüm içerik (başlıklar, paragraflar, liste öğeleri) çevrildi.
- ✅ **Kod Blokları:** Kodun kendisi orijinal bırakıldı ancak içindeki yorum satırları (`// comments`) çevrildi.
- ✅ **Anchor Linkler:** `{#id}` şeklindeki bağlantı kimlikleri orijinal haliyle korundu.
- ✅ **Glossary Uyumu:** `GLOSSARY.md` dosyasındaki terimler kullanıldı.
- ✅ **Bilişsel Yük:** "Kolayca", "basitçe", "zaten" gibi okuyucuyu zorlayabilecek ifadelerden kaçınıldı.
- ✅ **Yerel Test:** `pnpm run dev` komutuyla sayfa yerelde görüntülendi ve hatalı bir render (kırık link vb.) olmadığı onaylandı.

Closes #41 